### PR TITLE
Fix the mapping for container env vars to aca-secrets

### DIFF
--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -24,12 +24,12 @@
       "value": {
         "settings": [
           {
-            "name": "openaiApiKey",
+            "name": "OPENAI_API_KEY",
             "value": "${OPENAI_API_KEY}",
             "secret": true
           },
           {
-            "name": "omdbApiKey",
+            "name": "OMDB_API_KEY",
             "value": "${OMDB_API_KEY}",
             "secret": true
           }


### PR DESCRIPTION
As part of previous PR: https://github.com/savannahostrowski/cinest/pull/2

Infrastructure was updated from putting the OMDB_API_KEY and OPENAI_API_KEY directly in the env from the container-revision to, instead, putting this values within the AzureContainerApp secrets and creating an env-var within the revision which points to the aca-secret holding the value.

The change required a strategy to set upper-case, SNAKE_CASE env variables as aca-secrets because the aca-secrets has the same naming restrictions as a KeyVault secret. So, it is not possible to set a secret with the name `OPENAI_API_KEY` as aca-secret.  The implemented strategy runs lowerCase() function and replaces `_` for `-`.

The change was done correctly, but ended up breaking the python application because the application is expecting to find `OMDB_API_KEY` and `OPENAI_API_KEY` in env, but the changes from the infrastructure updated the name of this env vars as `openaiApiKey` and `omdbApiKey`, here: https://github.com/savannahostrowski/cinest/pull/2/files#diff-834bc11e3cb55730076a7d70767b75f794dc9a37305f27d99926e0fd24363c13R27

The change on this PR restores the name for the ENV VARS are it is expected by the python application.

The strategy mentioned before is still applied based on the new names, creating env vars for the container like:
```bicep
{
      name: 'OMDB_API_KEY'
      secretRef: 'omdb-api-key'
},
{
      name: 'OPENAI_API_KEY'
      secretRef: 'openai-api-key'
},
```

and then, setting aca-secrets as:

![image](https://github.com/savannahostrowski/cinest/assets/24213737/a305bcab-b206-4fe5-b67b-6f4225c1fa42)

Allowing the revision to pull the values from the aca-secrets.